### PR TITLE
Remove SharedTicker.speed from tick function

### DIFF
--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -282,7 +282,7 @@ class MovieClip extends Container {
             }
             return;
         }
-        let seconds = tickerDeltaTime / SharedTicker.speed / PIXI.settings.TARGET_FPMS / 1000;
+        let seconds = tickerDeltaTime /  PIXI.settings.TARGET_FPMS / 1000;
         this.advance(seconds);
     }
 

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -282,7 +282,7 @@ class MovieClip extends Container {
             }
             return;
         }
-        let seconds = tickerDeltaTime /  PIXI.settings.TARGET_FPMS / 1000;
+        let seconds = tickerDeltaTime / PIXI.settings.TARGET_FPMS / 1000;
         this.advance(seconds);
     }
 


### PR DESCRIPTION
To increase speed of all movieclips, better to use SharedTicker.speed instead of setting framerate for each movieclip.