### PR TITLE
Update documentation website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install pixi-animate
 
 ## Documentation
 
-http://jiborobot.github.io/pixi-animate/
+https://pixijs.io/pixi-animate/
 
 ## Typescript
 You can use require to get the namespace for PixiAnimate, or use a triple slash reference for using the PIXI.animate namespace.


### PR DESCRIPTION
I noticed the url for the documentation site in the readme resulted in a 404 not found. This pr should update it with the real url