### PR TITLE
 Fix for overshooting end frame when FPS is low

### DIFF
--- a/src/animate/AnimatorTimeline.js
+++ b/src/animate/AnimatorTimeline.js
@@ -63,7 +63,20 @@ class AnimatorTimeline {
          */
         this.callback = callback;
 
+        /**
+         * State of the instance's `loop` property at timeline init
+         * @name PIXI.animate.AnimatorTimeline#_originalLoop
+         * @type {Boolean}
+         * @private
+         */
+        this._originalLoop = !instance ? null : instance.loop;
+
+
         if (instance) {
+            if(!this.loop && instance.loop){
+                //To prevent overshooting the end frame and looping back around
+                instance.loop = false;
+            }
             instance.gotoAndStop(start);
             instance._beforeUpdate = this._update;
         }
@@ -76,6 +89,9 @@ class AnimatorTimeline {
      */
     destroy() {
         this.instance._beforeUpdate = null;
+        if(this._originalLoop !== null){
+            this.instance.loop = this._originalLoop;
+        }
         this.init(null, 0, 0, false, null);
         AnimatorTimeline._pool.push(this);
     }
@@ -100,6 +116,10 @@ class AnimatorTimeline {
                 instance.gotoAndPlay(this.start);
             } else {
                 instance.stop();
+                if(this._originalLoop !== null){
+                    instance.loop = this._originalLoop;
+                    this._originalLoop = null;
+                }
                 if (this.callback) {
                     completed = this.callback;
                 }

--- a/src/animate/AnimatorTimeline.js
+++ b/src/animate/AnimatorTimeline.js
@@ -61,7 +61,7 @@ class AnimatorTimeline {
          * @type {Function}
          * @readOnly
          */
-        this.callback = callback; 
+        this.callback = callback;
 
         if (instance) {
             //Prevent overshooting the end frame and looping back around:

--- a/src/animate/AnimatorTimeline.js
+++ b/src/animate/AnimatorTimeline.js
@@ -61,22 +61,11 @@ class AnimatorTimeline {
          * @type {Function}
          * @readOnly
          */
-        this.callback = callback;
-
-        /**
-         * State of the instance's `loop` property at timeline init
-         * @name PIXI.animate.AnimatorTimeline#_originalLoop
-         * @type {Boolean}
-         * @private
-         */
-        this._originalLoop = !instance ? null : instance.loop;
-
+        this.callback = callback; 
 
         if (instance) {
-            if(!this.loop && instance.loop){
-                //To prevent overshooting the end frame and looping back around
-                instance.loop = false;
-            }
+            //Prevent overshooting the end frame and looping back around:
+            instance.loop = false;
             instance.gotoAndStop(start);
             instance._beforeUpdate = this._update;
         }
@@ -89,9 +78,6 @@ class AnimatorTimeline {
      */
     destroy() {
         this.instance._beforeUpdate = null;
-        if(this._originalLoop !== null){
-            this.instance.loop = this._originalLoop;
-        }
         this.init(null, 0, 0, false, null);
         AnimatorTimeline._pool.push(this);
     }
@@ -116,10 +102,6 @@ class AnimatorTimeline {
                 instance.gotoAndPlay(this.start);
             } else {
                 instance.stop();
-                if(this._originalLoop !== null){
-                    instance.loop = this._originalLoop;
-                    this._originalLoop = null;
-                }
                 if (this.callback) {
                     completed = this.callback;
                 }


### PR DESCRIPTION
Addresses issue of overshooting the ending frame of an AnimatorTimeline on low-performing devices when the MovieClip's loop property is true and the end frame of the animation is also the last frame of the MovieClip's Timeline.

This isn't my favorite solution for this problem. I think the right way to deal with this would be to make the Animator or AnimatorTimeline responsible for advancing the MovieClip's Timeline, but that seems like it would be a relatively larger change, and I'm assuming there's a reason the Animator wasn't made that way in the first place.