### PR TITLE
Module typings fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install pixi-animate
 https://pixijs.io/pixi-animate/
 
 ## Typescript
-You can use require to get the namespace for PixiAnimate, or use a triple slash reference for using the PIXI.animate namespace.
+You can use require to get the namespace for PixiAnimate:
 ```typescript
 // Note: Must also include the pixi.js typings globally!
 import animate = require('pixi-animate');
@@ -32,12 +32,19 @@ import animate = require('pixi-animate');
 let myMC:animate.MovieClip = new animate.MovieClip();
 ```
 
+Or use a triple slash reference for using the PIXI.animate namespace:
 ```typescript
 // Note: Must also include the pixi.js typings globally!
 /// <reference path="node_modules/pixi-animate/ambient.d.ts" />
 require('pixi-animate');
 
 let myMC:PIXI.animate.MovieClip = new PIXI.animate.MovieClip();
+```
+
+Or simply import pixi-animate (after importing pixi.js):
+```typescript
+// Note: Must also include the pixi.js typings globally!
+import('pixi-animate);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let myMC:PIXI.animate.MovieClip = new PIXI.animate.MovieClip();
 Or simply import pixi-animate (after importing pixi.js):
 ```typescript
 // Note: Must also include the pixi.js typings globally!
-import('pixi-animate);
+import('pixi-animate');
 ```
 
 ## License

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // Typings for PixiAnimate 1.0.0, requires Pixi.js typings
-declare namespace animate {
+declare namespace PIXI.animate {
 
     export namespace utils {
         export function hexToUint(hex:string|number):number;
@@ -152,4 +152,6 @@ declare namespace animate {
     }
 }
 
-export = animate;
+declare module "pixi-animate" {
+    export = PIXI.animate;
+}


### PR DESCRIPTION
Updated index.d.ts to be consistent with the way pixi-sound exports its type definitions. This enables importing of pixi-animate type definitions via `/// <reference types="pixi-animate" />` rather than `/// <reference path="../node_modules/pixi-animate/ambient.d.ts" />` and also importing of the module code via `import 'pixi-animate';` rather than `import * as animate from 'pixi-animate';`