### PR TITLE
Smoother FPS changes

### DIFF
--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -365,6 +365,7 @@ class MovieClip extends Container {
     set framerate(value) {
         if (value > 0) {
             if (this._framerate) {
+                //recalculate time based on difference between new and old framerate:
                 this._t *= this._framerate / value;
             } else {
                 this._t = this.currentFrame / value;

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -364,7 +364,7 @@ class MovieClip extends Container {
     }
     set framerate(value) {
         if (value > 0) {
-            if(this._framerate) {
+            if (this._framerate) {
                 this._t *= this._framerate / value;
             } else {
                 this._t = this.currentFrame / value;

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -364,10 +364,9 @@ class MovieClip extends Container {
     }
     set framerate(value) {
         if (value > 0) {
-            if(this._framerate){
+            if(this._framerate) {
                 this._t *= this._framerate / value;
-            }
-            else{
+            } else {
                 this._t = this.currentFrame / value;
             }
             this._framerate = value;

--- a/src/animate/MovieClip.js
+++ b/src/animate/MovieClip.js
@@ -364,9 +364,14 @@ class MovieClip extends Container {
     }
     set framerate(value) {
         if (value > 0) {
+            if(this._framerate){
+                this._t *= this._framerate / value;
+            }
+            else{
+                this._t = this.currentFrame / value;
+            }
             this._framerate = value;
             this._duration = value ? this._totalFrames / value : 0;
-            this._t = this.currentFrame / value;
         } else {
             this._t = this._framerate = this._duration = 0;
         }


### PR DESCRIPTION
When changing FPS of a playing MovieClip, the current time value was being recalculated to be at the start of the current frame at the new FPS. This can cause a stutter because we're going back in time by a small amount. Multiple changes to FPS in less than 1/FPS seconds cause a hang in the animation.

This change updates the time more accurately as to actual progress through the animation, eliminating stutter/hang on FPS change.