### PR TITLE
add typings for setTint function to MovieClip

### DIFF
--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -89,6 +89,7 @@ declare namespace PIXI.animate {
         ps(alias:string, loop?:boolean):MovieClip;
         advance(time:number):void;
         destroy():void;
+        setTint(tint:number):MovieClip;
         static extend(child:Function):typeof MovieClip;
         static e(child:Function):typeof MovieClip;
         static INDEPENDENT:number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,7 @@ declare namespace PIXI.animate {
         ps(alias:string, loop?:boolean):MovieClip;
         advance(time:number):void;
         destroy():void;
+        setTint(tint:number):MovieClip;
         static extend(child:Function):typeof MovieClip;
         static e(child:Function):typeof MovieClip;
         static INDEPENDENT:number;


### PR DESCRIPTION
PixiAnimate adds a setTint function to DisplayObject - overriding the typings on DisplayObject is tricky (or impossible), and the mixin strategy should be rethought for V2, but this change gets more accurate typings for MovieClip