### PR TITLE
allow disabling automatic stage instantiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "6"
+    - "8"
 
 install:
     - npm install xvfb-maybe

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -15,8 +15,10 @@ declare namespace PIXI.animate {
 
     interface LoadOptions {
         stage:any;
-        parent:PIXI.Container;
-        basePath:string;
+        parent?:PIXI.Container;
+        basePath?:string;
+        complete?:LoadCallback;
+        createInstance?:boolean;
     }
 
     type LoadCallback = (instance:MovieClip) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,8 +15,10 @@ declare namespace PIXI.animate {
 
     interface LoadOptions {
         stage:any;
-        parent:PIXI.Container;
-        basePath:string;
+        parent?:PIXI.Container;
+        basePath?:string;
+        complete?:LoadCallback;
+        createInstance?:boolean;
     }
 
     type LoadCallback = (instance:MovieClip) => void;

--- a/src/animate/load.js
+++ b/src/animate/load.js
@@ -6,6 +6,7 @@
  * @param {Object} [options.stage.assets] Assets used to preload
  * @param {PIXI.Container} options.parent The Container to auto-add the stage to.
  * @param {String} [options.basePath] Base root directory
+ * @param {boolean} [options.createInstance] enable or disable automatic instantiation of stage
  * @return {PIXI.loaders.Loader} instance of PIXI resource loader
  */
 /**
@@ -109,13 +110,14 @@ const load = function(options, parent, complete, basePath, loader, metadata) {
         stage: null,
         parent: null,
         basePath: '',
-        complete: null
+        complete: null,
+        createInstance: true
     }, options || {});
 
     loader = loader || new PIXI.loaders.Loader();
 
     function done() {
-        let instance = typeof options.stage === "function" ? new options.stage() : null;
+        let instance = (options.createInstance && typeof options.stage === "function") ? new options.stage() : null;
         if (options.parent) {
             options.parent.addChild(instance);
         }


### PR DESCRIPTION
Added flag to LoadOptions to prevent automatic instantiation of stage upon load complete. Instantiating an entire stage can be very expensive, and isn't always necessary.